### PR TITLE
Don't treat Google app measurement DBs as root files

### DIFF
--- a/app/src/main/cpp/nativehooks.cpp
+++ b/app/src/main/cpp/nativehooks.cpp
@@ -67,7 +67,8 @@ int fake_stat(const char *filename, struct stat *file_info) {
 }
 
 bool is_file_related_to_root(const char *filename) {
-    if (strstr(filename, "su") || strstr(filename, "/proc/net/unix") ||
+    if ((strstr(filename, "su") && !strstr(filename, "measurement")) ||
+        strstr(filename, "/proc/net/unix") ||
         strstr(filename, "magisk") || strstr(filename, "busybox") ||
         strstr(filename, "/data/adb/.boot_count") || strstr(filename, "Superuser") ||
         strstr(filename, "daemonsu") || strstr(filename, "SuperSU"))

--- a/app/src/main/java/com/gauravssnl/bypassrootcheck/pro/MainModule.kt
+++ b/app/src/main/java/com/gauravssnl/bypassrootcheck/pro/MainModule.kt
@@ -167,7 +167,8 @@ class MainModule(base: XposedInterface, param: ModuleLoadedParam) : XposedModule
 }
 
 private fun isFileRootAccessRelated(fileName: String): Boolean {
-    return fileName.contains("magisk") || fileName.contains("su")
+    return fileName.contains("magisk")
+            || (fileName.contains("su") && !fileName.contains("measurement"))
             || fileName.contains("busybox") || fileName.contains("Superuser")
             || fileName.contains("daemonsu") || fileName.contains("SuperSU")
             || fileName.contains("/data/adb/.boot_count")


### PR DESCRIPTION
A side effect of treating all files with `su` in name is preventing some Google APIs from work, like `/data/user/0/<package>/databases/google_app_measurement.db`. This can be used to detect the bypass or just make the app unstable or crash due to app database being unavailable.